### PR TITLE
Fix return type of `ListRealms`

### DIFF
--- a/pkg/common/client.go
+++ b/pkg/common/client.go
@@ -517,13 +517,13 @@ func (c *Client) list(resourcePath, resourceName string, unMarshalListFunc func(
 	return objs, nil
 }
 
-func (c *Client) ListRealms() ([]*v1alpha1.KeycloakRealm, error) {
+func (c *Client) ListRealms() ([]*v1alpha1.KeycloakAPIRealm, error) {
 	result, err := c.list("realms", "realm", func(body []byte) (T, error) {
-		var realms []*v1alpha1.KeycloakRealm
+		var realms []*v1alpha1.KeycloakAPIRealm
 		err := json.Unmarshal(body, &realms)
 		return realms, err
 	})
-	resultAsRealm, ok := result.([]*v1alpha1.KeycloakRealm)
+	resultAsRealm, ok := result.([]*v1alpha1.KeycloakAPIRealm)
 	if !ok {
 		return nil, err
 	}
@@ -946,7 +946,7 @@ type KeycloakInterface interface {
 	GetRealm(realmName string) (*v1alpha1.KeycloakRealm, error)
 	UpdateRealm(specRealm *v1alpha1.KeycloakRealm) error
 	DeleteRealm(realmName string) error
-	ListRealms() ([]*v1alpha1.KeycloakRealm, error)
+	ListRealms() ([]*v1alpha1.KeycloakAPIRealm, error)
 
 	CreateClient(client *v1alpha1.KeycloakAPIClient, realmName string) error
 	GetClient(clientID, realmName string) (*v1alpha1.KeycloakAPIClient, error)

--- a/pkg/common/client_test.go
+++ b/pkg/common/client_test.go
@@ -203,8 +203,8 @@ func TestClient_ListRealms(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		assert.Equal(t, RealmsCreatePath, req.URL.Path)
 		assert.Equal(t, req.Method, http.MethodGet)
-		var list []*v1alpha1.KeycloakRealm
-		list = append(list, realm)
+		var list []*v1alpha1.KeycloakAPIRealm
+		list = append(list, realm.Spec.Realm)
 		json, err := jsoniter.Marshal(list)
 		assert.NoError(t, err)
 

--- a/pkg/common/keycloakClient_moq.go
+++ b/pkg/common/keycloakClient_moq.go
@@ -203,7 +203,7 @@ var _ KeycloakInterface = &KeycloakInterfaceMock{}
 //             ListIdentityProvidersFunc: func(realmName string) ([]*v1alpha1.KeycloakIdentityProvider, error) {
 // 	               panic("mock out the ListIdentityProviders method")
 //             },
-//             ListRealmsFunc: func() ([]*v1alpha1.KeycloakRealm, error) {
+//             ListRealmsFunc: func() ([]*v1alpha1.KeycloakAPIRealm, error) {
 // 	               panic("mock out the ListRealms method")
 //             },
 //             ListUserClientRolesFunc: func(realmName string, clientID string, userID string) ([]*v1alpha1.KeycloakUserRole, error) {
@@ -379,7 +379,7 @@ type KeycloakInterfaceMock struct {
 	ListIdentityProvidersFunc func(realmName string) ([]*v1alpha1.KeycloakIdentityProvider, error)
 
 	// ListRealmsFunc mocks the ListRealms method.
-	ListRealmsFunc func() ([]*v1alpha1.KeycloakRealm, error)
+	ListRealmsFunc func() ([]*v1alpha1.KeycloakAPIRealm, error)
 
 	// ListUserClientRolesFunc mocks the ListUserClientRoles method.
 	ListUserClientRolesFunc func(realmName string, clientID string, userID string) ([]*v1alpha1.KeycloakUserRole, error)
@@ -2362,7 +2362,7 @@ func (mock *KeycloakInterfaceMock) ListIdentityProvidersCalls() []struct {
 }
 
 // ListRealms calls ListRealmsFunc.
-func (mock *KeycloakInterfaceMock) ListRealms() ([]*v1alpha1.KeycloakRealm, error) {
+func (mock *KeycloakInterfaceMock) ListRealms() ([]*v1alpha1.KeycloakAPIRealm, error) {
 	if mock.ListRealmsFunc == nil {
 		panic("KeycloakInterfaceMock.ListRealmsFunc: method is nil but KeycloakInterface.ListRealms was just called")
 	}


### PR DESCRIPTION
`KeycloakInterface.ListRealms` was unmarshalling the API response
to the CR type `KeycloakRealm` instead of the API type
`KeycloakAPIRealm`. Update the function signature and implementation
as well as the unit tests to use the API type instead.